### PR TITLE
Add webpack-glsl-loader to the starter

### DIFF
--- a/bundler/webpack.common.js
+++ b/bundler/webpack.common.js
@@ -41,6 +41,12 @@ module.exports = {
                 use: [MiniCSSExtractPlugin.loader, 'css-loader'],
             },
 
+            // GLSL
+            {
+                test: /\.(glsl|vs|fs|vert|frag)$/,
+                use: ['webpack-glsl-loader'],
+            },
+
             // Images
             {
                 test: /\.(jpg|png|gif|svg)$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "webpack": "^5.41.1",
                 "webpack-cli": "^4.7.2",
                 "webpack-dev-server": "^3.11.2",
+                "webpack-glsl-loader": "^1.0.1",
                 "webpack-merge": "^5.8.0"
             }
         },
@@ -4422,6 +4423,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+            "integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
+            "dev": true
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6525,6 +6532,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/path": {
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz",
+            "integrity": "sha1-y8dWk1XLPIOv60rOQ+z/lSMeWn0=",
+            "dev": true
         },
         "node_modules/path-dirname": {
             "version": "1.0.2",
@@ -9083,6 +9096,16 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/webpack-glsl-loader": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-glsl-loader/-/webpack-glsl-loader-1.0.1.tgz",
+            "integrity": "sha1-cqDjAZK9V5R9YNbVBckVvmgNCsw=",
+            "dev": true,
+            "dependencies": {
+                "fs": "0.0.2",
+                "path": "^0.11.14"
             }
         },
         "node_modules/webpack-log": {
@@ -12685,6 +12708,12 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
+        "fs": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
+            "integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
+            "dev": true
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -14266,6 +14295,12 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path": {
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz",
+            "integrity": "sha1-y8dWk1XLPIOv60rOQ+z/lSMeWn0=",
             "dev": true
         },
         "path-dirname": {
@@ -16262,6 +16297,16 @@
                         "has-flag": "^3.0.0"
                     }
                 }
+            }
+        },
+        "webpack-glsl-loader": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-glsl-loader/-/webpack-glsl-loader-1.0.1.tgz",
+            "integrity": "sha1-cqDjAZK9V5R9YNbVBckVvmgNCsw=",
+            "dev": true,
+            "requires": {
+                "fs": "0.0.2",
+                "path": "^0.11.14"
             }
         },
         "webpack-log": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "webpack": "^5.41.1",
         "webpack-cli": "^4.7.2",
         "webpack-dev-server": "^3.11.2",
+        "webpack-glsl-loader": "^1.0.1",
         "webpack-merge": "^5.8.0"
     }
 }


### PR DESCRIPTION
## Description
Add the module `webpack-glsl-loader` to the starter, which will be used to load WebGL shader files written in GLSL language.

## Test
Test with my own project https://github.com/cyclexit/solar-system (private now).
![image](https://user-images.githubusercontent.com/58613469/152022278-a8757fd8-a6eb-4cc7-a130-ba672aad8dc5.png)
![272841636_1058750381362253_5581464984829052789_n](https://user-images.githubusercontent.com/58613469/152022324-3ba312b7-fb69-4c16-a6c4-3071ac71f9b2.png)

